### PR TITLE
Customer sign in

### DIFF
--- a/app/controllers/public/registrations_controller.rb
+++ b/app/controllers/public/registrations_controller.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Public::RegistrationsController < Devise::RegistrationsController
-  # before_action :configure_sign_up_params, only: [:create]
+   before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
@@ -41,9 +41,9 @@ class Public::RegistrationsController < Devise::RegistrationsController
   # protected
 
   # If you have extra params to permit, append them to the sanitizer.
-  # def configure_sign_up_params
-  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
-  # end
+   def configure_sign_up_params
+     devise_parameter_sanitizer.permit(:sign_up, keys: [:family_name, :first_name, :family_name_kana, :first_name_kana, :post_code, :address, :phone_number, :])
+   end
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_account_update_params

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -19,11 +19,13 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
-  def after_path_for(resource)
+  def after_sign_in_path_for(resource)
     items_path
   end 
   
-  
+  def after_sign_out_path_for(resource)
+    "/"
+  end  
 
   # protected
 

--- a/app/controllers/public/sessions_controller.rb
+++ b/app/controllers/public/sessions_controller.rb
@@ -2,6 +2,7 @@
 
 class Public::SessionsController < Devise::SessionsController
   # before_action :configure_sign_in_params, only: [:create]
+  bafore_action :customer_state, only: [:create]
 
   # GET /resource/sign_in
   # def new
@@ -18,7 +19,24 @@ class Public::SessionsController < Devise::SessionsController
   #   super
   # end
 
+  def after_path_for(resource)
+    items_path
+  end 
+  
+  
+
   # protected
+
+  def customer_state
+    customer=Costomer.find_by(email: params[:customer][:email])
+    return if customer.nil?
+    return unless customer.valid_password?(params:[customer][:password])
+    if customer.is_active==false
+      redirect_to new_customer_registration_path and return
+    end 
+  end    
+
+
 
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params


### PR DESCRIPTION
customerのsign_in/up/outの機能作成
sign_in
create実行前にis_activeカラムの状態によってログインさせるかさせないか判断
after_sign_in_pathでログイン後の遷移先指定

sign_up
ストロングパラメーターの指定

sign_out
別で作るとコンフリクトが起きそうなので一緒に作成しました
after_sign_out_pathでログアウト後の遷移先指定
