### PR TITLE
商品一覧画面の全件表示の修正

### DIFF
--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -3,7 +3,7 @@
  <div class="col-md-2">
  </div>
   <div class="col-md-10">
-    <h2>商品一覧(全<%=@items.count %>件)</h2>
+    <h2>商品一覧(全<%=@items.total_count %>件)</h2>
     <div class="item_collection d-flex flex-wrap">
     <% @items.each do |item| %>
     <div class="m-2">


### PR DESCRIPTION
ページネーションを使用していて、ページごとの合計件数になってしまっていたのでtotalの商品件数の表示に修正